### PR TITLE
Cd issue 3

### DIFF
--- a/app/components/single-reminder.js
+++ b/app/components/single-reminder.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  model(params) {
+    return this.store.findRecord('reminder', params.id);
+  }
+});

--- a/app/router.js
+++ b/app/router.js
@@ -7,7 +7,9 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
-  this.route('reminders');
+  this.route('reminders', function(){
+    this.route('reminder', { path: '/:id' });
+  });
 });
 
 export default Router;

--- a/app/routes/reminders/reminder.js
+++ b/app/routes/reminders/reminder.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model(params) {
+    return this.get('store').findRecord('reminder', params.id);
+  }
+});

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,0 +1,3 @@
+.active {
+  color: red;
+}

--- a/app/templates/components/single-reminder.hbs
+++ b/app/templates/components/single-reminder.hbs
@@ -1,0 +1,6 @@
+
+<div class="reminder">
+  <h3 class="reminder-title">{{reminder.title}}</h3>
+  <p>{{reminder.body}}</p>
+  <p>{{reminder.date}}</p>
+</div>

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,10 +1,12 @@
 <h1>remEMBER Donatello</h1>
 
-{{#each model as |reminder|}}
-  <div class='reminder-item'>
-    <h3>{{reminder.title}}</h3>
-    <p>{{reminder.body}}</p>
-  </div>
-{{/each}}
+<div>
+  {{#each model as |reminder|}}
+    {{#link-to 'reminders.reminder' reminder}}
+      <h3 class="reminder-item">{{reminder.title}}</h3>
+    {{/link-to}}
+  {{/each}}
+</div>
+
 
 {{outlet}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,0 +1,2 @@
+
+{{single-reminder reminder=model}}

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -14,7 +14,7 @@ test('viewing the homepage', function(assert) {
 
   andThen(function() {
     assert.equal(currentURL(), '/reminders');
-    assert.equal(Ember.$('.reminder-item').length, 5);
+    assert.equal(Ember.$('.reminder-item').length, 5, 'see all reminders');
   });
 });
 
@@ -25,7 +25,7 @@ test('clicking on an individual item', function(assert) {
   click('.reminder-item:first');
 
   andThen(function() {
-    assert.equal(currentURL(), '/reminders/reminder/1');
+    assert.equal(currentURL(), '/reminders/1');
     assert.equal(Ember.$('.reminder-item:first').text().trim(), Ember.$('.reminder-title').text().trim());
   });
 });


### PR DESCRIPTION
@martensonbj  @Tman22 

## Purpose

To allow the user to click on each reminder title and see the details render below the reminder list.
Closes issue #3

## Approach

Added single reminder component that is rendered by unique id generated by Ember.

### Learning

We originally tried to create a nested route and then decided to create a separate component for the single reminder. We later realized both approaches would work and opted to stay with the component. The docs we used are listed below.

[Building a component](https://guides.emberjs.com/v2.12.0/tutorial/simple-component/)
[Defining your routes](https://guides.emberjs.com/v2.12.0/routing/defining-your-routes/#toc_basic-routes)

### Test coverage 

We wrote an acceptance test to check that the title of the selected reminder matched the title of the "expanded" reminder.

### Follow-up tasks

- [Issue #4](https://github.com/turingschool-projects/1611-remember-donatello/issues/4)
