### PR TITLE
Add conditional statement to only render existing reminders

### DIFF
--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,17 +1,19 @@
 <h1>remEMBER Donatello</h1>
 
 <div>
-  {{#each model as |reminder|}}
-    {{#link-to 'reminders.reminder' reminder}}
-      <h3 class="reminder-item">{{reminder.title}}</h3>
-    {{/link-to}}
-  {{/each}}
+  {{#if model}}
+    {{#each model as |reminder|}}
+      {{#link-to 'reminders.reminder' reminder}}
+        <h3 class="reminder-item">{{reminder.title}}</h3>
+      {{/link-to}}
+    {{/each}}
+  {{else}}
+    <h2 class="add-reminder">Add a new reminder</h2>
+  {{/if}}
   {{#link-to 'reminders.new'}}
-    <button>Add Reminder</button>
+    <button class="add-btn">Add Reminder</button>
   {{/link-to}}
 </div>
-
-
 
 
 {{outlet}}

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -1,3 +1,3 @@
 export default function(server) {
-  server.createList('reminder', 5);
+  server.createList('reminder', 0);
 }

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -36,13 +36,13 @@ test('clicking on an individual item', function(assert) {
 
 test('adding a new reminder', function(assert) {
   server.createList('reminder', 5)
-  
+
   visit('/reminders/new');
   fillIn('.title', 'boots');
   fillIn('.body', 'pants');
   fillIn('.date', '2017-01-01');
   click('.save');
-  
+
   andThen(function() {
     assert.equal(currentURL(), '/reminders');
     assert.equal(Ember.$('.reminder-item').length, 6, 'see all reminders');
@@ -53,13 +53,13 @@ test('adding a new reminder', function(assert) {
 
 test('adding a new reminder', function(assert) {
   server.createList('reminder', 5)
-  
+
   visit('/reminders/new');
   fillIn('.title', 'boots');
   fillIn('.body', 'pants');
   fillIn('.date', '2017-01-01');
   click('.save');
-  
+
   click('.reminder-item:last');
   andThen(function() {
     assert.equal(currentURL(), '/reminders/6');
@@ -67,5 +67,23 @@ test('adding a new reminder', function(assert) {
     assert.equal(Ember.$('.reminder-body').text().trim(), 'pants');
     assert.equal(Ember.$('.reminder-date').text().trim(), '2017-01-01');
     server.shutdown();
+  });
+});
+
+test('instruction if no reminders present', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    assert.equal(Ember.$('.add-reminder').length, 1, 'see add reminder header');
+    assert.equal(Ember.$('.add-btn').length, 1, 'see add reminder button');
+  });
+});
+
+test('visit root and click add reminder button should take user to form', function(assert) {
+  visit('/');
+  click('.add-btn');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/reminders/new');
   });
 });


### PR DESCRIPTION
@martensonbj  @Tman22 closes #5 
## Purpose

Only display reminders if at least one reminder exists.

## Approach

Removes lorem ipsum reminders and wraps reminders list in conditional statement to check if a reminder currently exists.

### Learning

[Conditionals in ember](https://emberigniter.com/how-to-equals-conditional-comparison-handlebars/)

### Test coverage 

There are tests to validate that only the add reminder button shows on page load and also that the current url is updated when the add reminder button is clicked.

### Follow-up tasks

- [Issue #6 ](https://github.com/turingschool-projects/1611-remember-donatello/issues/6)